### PR TITLE
Add new 'tbd' scope to OOS status

### DIFF
--- a/synack.py
+++ b/synack.py
@@ -337,7 +337,7 @@ class synack:
             jsonResponse = response.json()
             j = 0
             while j < len(jsonResponse):
-                if jsonResponse[j]['status'] == "out":
+                if jsonResponse[j]['status'] in ["out","tbd"]:
                     tmpOOS = set()
                     for thisRule in range(len(jsonResponse[j]['rules'])):
                         url = urlparse(jsonResponse[j]['rules'][thisRule]['rule'])
@@ -424,7 +424,7 @@ class synack:
                                 path = "/" + "/".join(path.split('/')[1:])
                             else:
                                 continue
-                        if jsonResponse[j]['rules'][thisRule]['status'] == "out":
+                        if jsonResponse[j]['rules'][thisRule]['status'] in ["out","tbd"]:
                             oosDict = {
                                         'scheme' : scheme,
                                         'netloc': netloc,


### PR DESCRIPTION
TIKI-W003 introduced a new "tbd" scope for an entry that was temporarily removed that is incorrectly being added to the "in" list because it's not "out" - this is causing `getScope` to incorrectly return this as still being in scope.