### PR TITLE
Adding Mobile support to getAnalytics()

### DIFF
--- a/synack.py
+++ b/synack.py
@@ -632,6 +632,29 @@ class synack:
                             else:
                                 analyticsDict['status'] = str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['status'])
                             analytics.append(analyticsDict)
+        elif targetType == "Mobile":
+            if "value" in jsonResponse:
+                for value in range(len(jsonResponse['value'])):
+                    for exploitable_location in range(len(jsonResponse['value'][value]['exploitable_locations'])):
+                        analyticsDict = {}
+                        analyticsDict['codename'] = codename
+                        analyticsDict['vuln_category'] = str(jsonResponse['value'][value]['categories'][0])
+                        if len(jsonResponse['value'][value]['categories']) == 2:
+                            analyticsDict['vuln_subcategory'] = str(jsonResponse['value'][value]['categories'][1])
+                        if jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['type']:
+                            try:
+                                analyticsDict['type'] = str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['type'])
+                            except:
+                                analyticsDict['type'] = ""
+                            try:
+                                analyticsDict['value'] = str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['value'])
+                            except:
+                                analyticsDict['value'] = ""
+                            try:
+                                analyticsDict['status'] = str(jsonResponse['value'][value]['exploitable_locations'][exploitable_location]['status'])
+                            except:
+                                analyticsDict['status'] = ""                            
+                            analytics.append(analyticsDict)
             return analytics
 
 #############################################


### PR DESCRIPTION
Quick fix to add `mobile` target type support to `getAnalytics()` function.

Prior to this patch the following would throw an `assertion` as analytics would be `None` as Mobile type wasn't parsed/handled.
```
s1 = synack()
s1.getSessionToken()
s1.getAllTargets()
for target in s1.jsonResponse:
    codename = target['codename']
    if "Mobile" == s1.getCategory(codename):
        analytics = s1.getAnalytics(codename)
        assert analytics 
        exit(-1)
```
I tried to keep it consistent with how Web/Hosts are parsed by perhaps in the future something like `marshmallow` would make the serialization a lot cleaner. 
https://marshmallow.readthedocs.io/en/stable/

