### PR TITLE
Fix an issue with GOAT-W001 

### DIFF
--- a/synack.py
+++ b/synack.py
@@ -471,7 +471,7 @@ class synack:
                                         'wildcard': wildcard,
                                         'fullURI' : scheme+netloc
                                     }
-                    allRules.append(scopeDict)
+                        allRules.append(scopeDict)
                     j+=1
             return(list(allRules),list(oosRules))
         if category.lower() == "host":


### PR DESCRIPTION
Where there are 4 OOS rules followed by 1 in-scope rule, which led to an error due to incorrect indentation in this method.