### PR TITLE
Fix issue with getCIDRs not handling a list of CIDRs well

### DIFF
--- a/synack/synack.py
+++ b/synack/synack.py
@@ -509,9 +509,15 @@ class synack:
 ## This is a much faster method, previous method was causing problems on large hosts ##
 ########################################
     def getIPs(self, cidr):
+        cidrs = []
+        if type(cidr) == list:
+            cidrs = cidr
+        else: # string?
+            cidrs = [cidr]
         IPs = []
-        for ip in IPNetwork(cidr):
-            IPs.append(str(ip))
+        for cidr in cidrs:
+            for ip in IPNetwork(cidr):
+                IPs.append(str(ip))
         return(IPs)
     
 ##############################################


### PR DESCRIPTION
Recently (today?) there was an[other] API break and some targets are returning lists of CIDRs, breaking `getScope.py` with hosts. I updated this method to handle either a string or list parameter.